### PR TITLE
FIX: forbid extra spaces in output of lstlisting env, fix #3

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -30,6 +30,7 @@
   frame           = single,
   xleftmargin     = \ccwd,
   numbersep       = \ccwd,
+  columns         = fullflexible
 %  emphstyle       = {\color{blue}\small\ttfamily},
 %  emph            = {mkdir,rmdir,sudo,mount,umount,rm},
 }


### PR DESCRIPTION
增加 listing 选项 `columns = fullflexible`，参考
 - https://tex.stackexchange.com/a/4919/79060
 - `texdoc listings`, sec. 2.10