### PR TITLE
MOD: avoid copying line number

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -2,6 +2,7 @@
 % !TeX TXS-program:compile=txs:///latexmk/{}[-pdfxe -synctex=1 -interaction=nonstopmode -silent %]
 
 \documentclass{ctexrep}
+\usepackage{accsupp}
 \usepackage[margin=1in]{geometry}
 \usepackage{listings}
 \usepackage{xcolor}
@@ -26,13 +27,17 @@
   tabsize         = 4,
   gobble          = 2,
   numbers         = left,
-  numberstyle     = \tiny,
+  numberstyle     = \tiny\emptyaccsupp,
   frame           = single,
   xleftmargin     = \ccwd,
   numbersep       = \ccwd,
-  columns         = fullflexible
+  columns         = fullflexible,
 %  emphstyle       = {\color{blue}\small\ttfamily},
 %  emph            = {mkdir,rmdir,sudo,mount,umount,rm},
+}
+
+\newcommand\emptyaccsupp[1]{%
+  \BeginAccSupp{ActualText={}}#1\EndAccSupp{}%
 }
 
 \renewmenumacro{\menu}[>]{angularmenus}


### PR DESCRIPTION
避免复制行号，方便用户直接从 PDF 复制 - 粘贴多行代码。

参考：https://liam.page/2013/11/04/LaTeX-listings-copy/