### PR TITLE
标注北京理工大学镜像仍存在但仅限校内访问

### DIFF
--- a/chapter/mirror.tex
+++ b/chapter/mirror.tex
@@ -64,8 +64,8 @@
     \hline\hline
 %    \href{https://mirror.bjtu.edu.cn/}{北京交通大学}
 %    & \url{https://mirror.bjtu.edu.cn/ctan/systems/texlive/}\\
-%    \href{https://mirrors.bit.edu.cn/web/}{北京理工大学}
-%    & \url{https://mirrors.bit.edu.cn/CTAN/systems/texlive/}\\
+    \href{https://mirrors.bit.edu.cn/web/}{北京理工大学}（仅限校内访问）
+    & \url{https://mirrors.bit.edu.cn/CTAN/systems/texlive/}\\
     \href{https://mirrors.cqupt.edu.cn/}{重庆邮电大学}
     & \url{https://mirrors.cqupt.edu.cn/ctan/systems/texlive/}\\
     \href{https://mirrors.cernet.edu.cn/}{高校联合镜像}


### PR DESCRIPTION
https://mirror.bit.edu.cn 与 https://mirrors.bit.edu.cn 仍存在，但因外部网络攻击太多，改成仅限校内访问了。可参考 BITNP/issues#45。

TeX Live ISO 比较大且只用下载一次，从校内镜像站下载又快又不计费，有一定优势，所以希望加上。

不过未来维护时恐怕难以检查 https://mirrors.bit.edu.cn 存活状态，不确定你愿不愿意加。若不愿意，请告知。

---


P.S. 
这份指南真的整理得很好。我们最近[想改](https://github.com/BITNP/BIThesis-wiki/pull/601)我们那边的[安装指南](https://bithesis.bitnp.net/guide/getting-started.html)，碰到各种边缘情况，最后发现不少「正解」就是 install-latex-guide-zh-cn 里的办法。
我个人还考虑过删除我们那边的指南，直接链接到 install-latex-guide-zh-cn。不过 install-latex-guide-zh-cn 只有 PDF，所有内容都均匀地分散在六十多页里，而没有分节切段、`<details>`可折叠的网页版，不完全适配我们那边的场景。

